### PR TITLE
Add auto-unpark on movement, parked-vehicle cycling, and a settings toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.zip
 /.idea/
 *.iml
+/.claude/

--- a/ParkVehicle.lua
+++ b/ParkVehicle.lua
@@ -16,6 +16,7 @@
 ParkVehicle = {}
 ParkVehicle.inputName = "parkVehicle"
 ParkVehicle.modDir = g_parkVehicleSystem.modDir
+ParkVehicle.AUTO_UNPARK_DISTANCE = 3 -- meters a parked vehicle has to move (by any means) before it auto-unparks
 
 function ParkVehicle.prerequisitesPresent(specializations)
   return SpecializationUtil.hasSpecialization(Enterable, specializations)
@@ -73,6 +74,7 @@ function ParkVehicle:onLoad(savegame)
   spec.dirtyFlag = self:getNextDirtyFlag()
 
   spec.state = {}
+  spec.parkAnchorX, spec.parkAnchorY, spec.parkAnchorZ = 0, 0, 0
 
   local isEmpty = true
   if savegame ~= nil then
@@ -102,6 +104,9 @@ function ParkVehicle:onLoad(savegame)
   end
 
   self.spec_enterable:setIsTabbable(not spec.state[spec.uniqueUserId])
+  if spec.state[spec.uniqueUserId] then
+    spec.parkAnchorX, spec.parkAnchorY, spec.parkAnchorZ = localToWorld(self.rootNode, 0, 0, 0)
+  end
   spec.registrationKey = g_parkVehicleSystem:registerInstance(self)
 end
 
@@ -113,6 +118,18 @@ function ParkVehicle:onUpdate(dt, isActiveForInput, isSelected)
       self:setParkVehicleState(newValue)
       spec.inputPressed = false
     end
+
+    -- Auto-unpark: a parked vehicle that moves more than AUTO_UNPARK_DISTANCE
+    -- from where it was parked gets unparked automatically, regardless of what
+    -- moved it (player driving it, AI, being towed, ...).
+    if g_parkVehicleSystem.autoUnparkEnabled and self:getParkVehicleState() then
+      local x, y, z = localToWorld(self.rootNode, 0, 0, 0)
+      local dx, dy, dz = x - spec.parkAnchorX, y - spec.parkAnchorY, z - spec.parkAnchorZ
+      local distance = math.sqrt(dx * dx + dy * dy + dz * dz)
+      if distance >= ParkVehicle.AUTO_UNPARK_DISTANCE then
+        self:setParkVehicleState(false)
+      end
+    end
   end
 end
 
@@ -121,6 +138,9 @@ function ParkVehicle:setParkVehicleState(newValue)
   local spec = self.spec_parkvehicle
   self.spec_enterable:setIsTabbable(not newValue)
   spec.state[spec.uniqueUserId] = newValue
+  if newValue then
+    spec.parkAnchorX, spec.parkAnchorY, spec.parkAnchorZ = localToWorld(self.rootNode, 0, 0, 0)
+  end
   self:raiseDirtyFlags(spec.dirtyFlag)
 end
 
@@ -186,6 +206,9 @@ function ParkVehicle:onReadStream(streamId, connection)
     state[id] = value
     if id == spec.uniqueUserId then
       self.spec_enterable:setIsTabbable(not value)
+      if value then
+        spec.parkAnchorX, spec.parkAnchorY, spec.parkAnchorZ = localToWorld(self.rootNode, 0, 0, 0)
+      end
     end
     i = i + 1
   end
@@ -210,6 +233,9 @@ function ParkVehicle:onReadUpdateStream(streamId, timestamp, connection)
       local value = streamReadBool(streamId)
       if id == spec.uniqueUserId then
         self.spec_enterable:setIsTabbable(not value)
+        if value then
+          spec.parkAnchorX, spec.parkAnchorY, spec.parkAnchorZ = localToWorld(self.rootNode, 0, 0, 0)
+        end
       end
       spec.state[id] = value
     end
@@ -251,6 +277,21 @@ function ParkVehicle:onRegisterActionEvents(isActiveForInput)
       )
 
       g_inputBinding:setActionEventTextPriority(unparkAllEventId, GS_PRIO_VERY_LOW)
+
+      local _, cycleParkedEventId =
+      self:addActionEvent(
+          spec.actionEvents,
+          "PARKVEHICLE_CYCLE_PARKED",
+          self,
+          ParkVehicle.actionEventCycleParked,
+          false,
+          true,
+          false,
+          true,
+          nil
+      )
+
+      g_inputBinding:setActionEventTextPriority(cycleParkedEventId, GS_PRIO_VERY_LOW)
     end
   end
 end
@@ -262,6 +303,10 @@ end
 function ParkVehicle.actionEventParkVehicle(self, actionName, inputValue, callbackState, isAnalog)
   local spec = self.spec_parkvehicle
   spec.inputPressed = true
+end
+
+function ParkVehicle.actionEventCycleParked(self, actionName, inputValue, callbackState, isAnalog)
+  g_parkVehicleSystem:cycleParkedVehicles()
 end
 
 function ParkVehicle:saveToXMLFile(xmlFile, path)

--- a/ParkVehicleSettingsGui.lua
+++ b/ParkVehicleSettingsGui.lua
@@ -1,0 +1,66 @@
+--- Injects a "Park Vehicle" section (own header + "Auto-unpark vehicles" checkbox)
+--- into the native General Settings tab of the pause menu. Clones an existing
+--- section-title element and the "Is Train Tabbable" checkbox row (same kind of
+--- on/off vehicle-tabbing toggle), and rebinds the checkbox's click callback to
+--- our own persisted setting instead of the native g_settingsModel.
+ParkVehicleSettingsGui = {}
+
+function ParkVehicleSettingsGui.install()
+    InGameMenuSettingsFrame.onFrameOpen = Utils.appendedFunction(InGameMenuSettingsFrame.onFrameOpen, ParkVehicleSettingsGui.onFrameOpen)
+end
+
+function ParkVehicleSettingsGui.onFrameOpen(settingsFrame)
+    if settingsFrame.parkVehicleCheckbox ~= nil then
+        ParkVehicleSettingsGui.refreshCheckbox(settingsFrame.parkVehicleCheckbox)
+        return
+    end
+
+    local templateBox = settingsFrame.checkIsTrainTabbableBox
+    local layout = templateBox ~= nil and templateBox.parent or nil
+    if layout == nil then
+        return
+    end
+
+    -- Section header: clone any existing "General Settings" section title
+    -- (e.g. "Sound", "Camera") instead of appending into someone else's group.
+    for _, element in ipairs(layout.elements) do
+        if element.name == "sectionHeader" then
+            local header = element:clone(layout)
+            header:setText(g_i18n:getText("PARKVEHICLE_SETTINGS_SECTION"))
+            break
+        end
+    end
+
+    local clonedBox = templateBox:clone(layout)
+    local checkbox = clonedBox.elements[1]
+    local title = clonedBox.elements[2]
+    local tooltip = checkbox.elements[1]
+
+    title:setText(g_i18n:getText("PARKVEHICLE_AUTOUNPARK_SETTING"))
+    tooltip:setText(g_i18n:getText("PARKVEHICLE_AUTOUNPARK_SETTING_TOOLTIP"))
+
+    checkbox.target = ParkVehicleSettingsGui
+    checkbox:setCallback("onClickCallback", "onClickAutoUnpark")
+
+    ParkVehicleSettingsGui.refreshCheckbox(checkbox)
+
+    layout:invalidateLayout()
+
+    settingsFrame.parkVehicleCheckboxBox = clonedBox
+    settingsFrame.parkVehicleCheckbox = checkbox
+end
+
+--- Sets the checkbox's visual state directly instead of going through
+--- setIsChecked/setState: those skip the left/right highlight update
+--- (updateSelection) whenever the new state already equals the state the
+--- checkbox inherited from its clone source, which left the row visually
+--- stuck on the wrong side despite the underlying value being correct.
+function ParkVehicleSettingsGui.refreshCheckbox(checkbox)
+    checkbox.state = g_parkVehicleSystem.autoUnparkEnabled and BinaryOptionElement.STATE_RIGHT or BinaryOptionElement.STATE_LEFT
+    checkbox.skipAnimation = true
+    checkbox:updateSelection()
+end
+
+function ParkVehicleSettingsGui:onClickAutoUnpark(state, element)
+    g_parkVehicleSystem:setAutoUnparkEnabled(element:getIsChecked())
+end

--- a/ParkVehicleSystem.lua
+++ b/ParkVehicleSystem.lua
@@ -8,6 +8,13 @@
 ---@field counter integer Increased if an instance is registered, used as key within the table
 ParkVehicleSystem = {}
 
+-- Vehicle types which should never receive the parkVehicle specialization,
+-- because the base game already fixes their tabbable state on purpose
+-- (e.g. the Kaercher HDS 9/18-4 M car wash, type="highPressureWasher").
+ParkVehicleSystem.EXCLUDED_TYPES = {
+    ["highPressureWasher"] = true,
+}
+
 local ParkVehicleSystem_mt = Class(ParkVehicleSystem)
 
 ---
@@ -30,7 +37,56 @@ function ParkVehicleSystem:new(modName, modDir, inputManager, debug)
     self.counter = 0
     self.controlledVehicle = nil
 
+    self.autoUnparkEnabled = true
+    self:loadSettings()
+
     return self
+end
+
+function ParkVehicleSystem:getSettingsFilePath()
+    return getUserProfileAppPath() .. "modSettings/parkVehicle.xml"
+end
+
+function ParkVehicleSystem:loadSettings()
+    if g_dedicatedServerInfo ~= nil then
+        return
+    end
+
+    local filePath = self:getSettingsFilePath()
+    if not fileExists(filePath) then
+        return
+    end
+
+    local xml = loadXMLFile("ParkVehicleSettings", filePath)
+    if hasXMLProperty(xml, "ParkVehicle#autoUnparkEnabled") then
+        self.autoUnparkEnabled = Utils.getNoNil(getXMLBool(xml, "ParkVehicle#autoUnparkEnabled"), true)
+    end
+    delete(xml)
+end
+
+function ParkVehicleSystem:saveSettings()
+    if g_dedicatedServerInfo ~= nil then
+        return
+    end
+
+    local filePath = self:getSettingsFilePath()
+    local xml
+    if fileExists(filePath) then
+        xml = loadXMLFile("ParkVehicleSettings", filePath)
+    else
+        createFolder(getUserProfileAppPath() .. "modSettings")
+        xml = createXMLFile("ParkVehicleSettings", filePath, "ParkVehicle")
+    end
+
+    setXMLBool(xml, "ParkVehicle#autoUnparkEnabled", self.autoUnparkEnabled)
+    saveXMLFile(xml)
+    delete(xml)
+end
+
+---@param enabled boolean
+function ParkVehicleSystem:setAutoUnparkEnabled(enabled)
+    self.autoUnparkEnabled = enabled
+    self:saveSettings()
 end
 
 function ParkVehicleSystem:onMissionLoaded(mission)
@@ -59,7 +115,8 @@ function ParkVehicleSystem:installSpecialization(typeManager, specManager)
     local modified = 0
     for typeName, typeEntry in pairs(typeManager:getTypes()) do
         totalCount = totalCount + 1
-        if SpecializationUtil.hasSpecialization(Enterable, typeEntry.specializations) and
+        if not ParkVehicleSystem.EXCLUDED_TYPES[typeName] and
+            SpecializationUtil.hasSpecialization(Enterable, typeEntry.specializations) and
             not SpecializationUtil.hasSpecialization(Rideable, typeEntry.specializations) and
             not SpecializationUtil.hasSpecialization(ParkVehicle, typeEntry.specializations) then
             typeManager:addSpecialization(typeName, self.modName .. ".parkVehicle")
@@ -106,6 +163,38 @@ function ParkVehicleSystem:unparkAll()
     for _, value in pairs(self.instances) do
         value:setParkVehicleState(false)
     end
+end
+
+---@return ParkVehicle[] currently parked vehicle instances, in registration order
+function ParkVehicleSystem:getParkedVehicles()
+    local vehicles = {}
+    for i = 0, self.counter - 1 do
+        local instance = self.instances[i]
+        if instance ~= nil and instance:getParkVehicleState() then
+            table.insert(vehicles, instance)
+        end
+    end
+    return vehicles
+end
+
+-- Bypasses the normal Tab restriction: cycles only through vehicles that are
+-- currently parked, so you can reach them without unparking first.
+function ParkVehicleSystem:cycleParkedVehicles()
+    local vehicles = self:getParkedVehicles()
+    if #vehicles == 0 then
+        return
+    end
+
+    local currentVehicle = g_localPlayer:getCurrentVehicle()
+    local index = 1
+    for i, vehicle in ipairs(vehicles) do
+        if vehicle == currentVehicle then
+            index = (i % #vehicles) + 1
+            break
+        end
+    end
+
+    g_localPlayer:requestToEnterVehicle(vehicles[index])
 end
 
 function ParkVehicleSystem:setVehicle(vehicle)

--- a/loader.lua
+++ b/loader.lua
@@ -5,6 +5,7 @@ local modName = g_currentModName
 
 
 source(Utils.getFilename("ParkVehicleSystem.lua", directory))
+source(Utils.getFilename("ParkVehicleSettingsGui.lua", directory))
 
 local function validateVehicleTypes(typeManager)
     if typeManager.typeName == "vehicle" then
@@ -31,6 +32,10 @@ end
 
 local function init()
     g_parkVehicleSystem = ParkVehicleSystem:new(modName, directory, g_inputBinding, false)
+
+    if g_dedicatedServerInfo == nil then
+        ParkVehicleSettingsGui.install()
+    end
 
     -- hook into late load
     Mission00.loadMission00Finished = Utils.appendedFunction(Mission00.loadMission00Finished, loadedMission)

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -78,11 +78,37 @@ Değişiklik günlüğü:
       <de>Alle Fahrzeug entparken</de>
 	  <tr>Tüm araçları parktan çıkar</tr>
     </text>
+    <text name="input_PARKVEHICLE_CYCLE_PARKED">
+      <en>Cycle parked vehicles</en>
+      <de>Geparkte Fahrzeuge durchschalten</de>
+	  <tr>Park edilmiş araçlar arasında geçiş yap</tr>
+    </text>
+    <text name="PARKVEHICLE_CYCLE_PARKED">
+      <en>Cycle parked vehicles</en>
+      <de>Geparkte Fahrzeuge durchschalten</de>
+	  <tr>Park edilmiş araçlar arasında geçiş yap</tr>
+    </text>
+    <text name="PARKVEHICLE_SETTINGS_SECTION">
+      <en>Park Vehicle</en>
+      <de>Parkfunktion Für Fahrzeuge</de>
+	  <tr>Aracı Park Et</tr>
+    </text>
+    <text name="PARKVEHICLE_AUTOUNPARK_SETTING">
+      <en>Auto-unpark vehicles</en>
+      <de>Fahrzeuge automatisch entparken</de>
+	  <tr>Araçları otomatik parktan çıkar</tr>
+    </text>
+    <text name="PARKVEHICLE_AUTOUNPARK_SETTING_TOOLTIP">
+      <en>Automatically unparks a vehicle once it has moved a few meters, so you don't have to remember to do it yourself.</en>
+      <de>Entparkt ein Fahrzeug automatisch, sobald es sich einige Meter bewegt hat, damit du es nicht selbst tun musst.</de>
+	  <tr>Bir araç birkaç metre hareket ettiğinde otomatik olarak parktan çıkarılır, böylece bunu kendiniz yapmayı hatırlamanıza gerek kalmaz.</tr>
+    </text>
   </l10n>
 
   <actions>
     <action name="PARKVEHICLE_01" category="VEHICLE"/>
     <action name="PARKVEHICLE_UNPARK_ALL" />
+    <action name="PARKVEHICLE_CYCLE_PARKED" />
   </actions>
 
   <inputBinding>
@@ -91,6 +117,9 @@ Değişiklik günlüğü:
     </actionBinding>
     <actionBinding action="PARKVEHICLE_UNPARK_ALL">
       <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_lctrl KEY_t" />
+    </actionBinding>
+    <actionBinding action="PARKVEHICLE_CYCLE_PARKED">
+      <binding device="KB_MOUSE_DEFAULT" input="KEY_lctrl KEY_lshift KEY_tab" />
     </actionBinding>
   </inputBinding>
 </modDesc>


### PR DESCRIPTION
- Exclude vehicle types the base game already fixes as non-tabbable on purpose (e.g. the Kaercher HDS 9/18-4 M car wash, type="highPressureWasher") from receiving the ParkVehicle specialization at all, so the mod never overrides their native tabbable state.
- Auto-unpark: a parked vehicle now unparks itself once it has physically moved a few meters from where it was parked, regardless of what moved it (the player driving it, AI, being towed, etc.). Tracked via a world-space anchor position captured whenever a vehicle becomes parked, checked every frame against the vehicle's current position.
- Add a "Cycle parked vehicles" keybind (Ctrl+Shift+Tab) that lets players Tab-cycle specifically through parked vehicles, bypassing the normal Tab restriction, using the same native requestToEnterVehicle API the game's own vehicle switching uses.
- Add an "Auto-unpark vehicles" toggle so the feature is opt-out. Persisted to modSettings/parkVehicle.xml and exposed as its own "Park Vehicle" section (cloned section header + checkbox) in the native in-game General Settings menu, rather than a separate custom screen.
- Ignore the local .claude/ directory.